### PR TITLE
feat: add Wikipedia article quality filtering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "release:minor": "npm run release -- --release-as minor",
     "release:major": "npm run release -- --release-as major",
     "lint": "eslint .",
+    "test:article-quality": "node --experimental-strip-types scripts/test-article-quality.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/scripts/test-article-quality.ts
+++ b/frontend/scripts/test-article-quality.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+import {
+  evaluateArticleQuality,
+  isHighQualityArticle,
+  MIN_MEANINGFUL_EXTRACT_CHARACTERS,
+} from "../src/utils/articleQuality.ts"
+
+const validThumbnail = {
+  source: "https://upload.wikimedia.org/wikipedia/commons/example.jpg",
+  width: 480,
+  height: 320,
+}
+
+const highQualityArticle = {
+  title: "Marie Curie",
+  displaytitle: "Marie Curie",
+  extract:
+    "Marie Curie was a Polish and naturalised-French physicist and chemist who conducted pioneering research on radioactivity. She was the first woman to win a Nobel Prize and remains one of the best-known scientists in modern history.",
+  url: "https://en.wikipedia.org/wiki/Marie_Curie",
+  thumbnail: validThumbnail,
+  categories: ["Category:Polish physicists", "Category:Nobel laureates in Physics"],
+}
+
+assert.equal(isHighQualityArticle(highQualityArticle), true)
+
+const shortExtract = evaluateArticleQuality({
+  ...highQualityArticle,
+  title: "Tiny article",
+  extract: "Too short.",
+})
+
+assert.equal(shortExtract.isHighQuality, false)
+assert.equal(shortExtract.issues.some((issue) => issue.type === "short-extract"), true)
+assert.equal(MIN_MEANINGFUL_EXTRACT_CHARACTERS > 0, true)
+
+const disambiguationByTitle = evaluateArticleQuality({
+  ...highQualityArticle,
+  title: "Mercury (disambiguation)",
+  categories: ["Category:Disambiguation pages"],
+})
+
+assert.equal(disambiguationByTitle.isHighQuality, false)
+assert.equal(disambiguationByTitle.issues.some((issue) => issue.type === "disambiguation"), true)
+
+const disambiguationByExtract = evaluateArticleQuality({
+  ...highQualityArticle,
+  title: "Mercury",
+  extract:
+    "Mercury may refer to several different topics, including a chemical element, a planet, a Roman deity, newspapers, songs, and other uses across science and culture.",
+  categories: ["Category:Language and terminology"],
+})
+
+assert.equal(disambiguationByExtract.isHighQuality, false)
+assert.equal(disambiguationByExtract.issues.some((issue) => issue.field === "extract"), true)
+
+const listPage = evaluateArticleQuality({
+  ...highQualityArticle,
+  title: "List of physicists",
+  categories: ["Category:Lists of scientists"],
+})
+
+assert.equal(listPage.isHighQuality, false)
+assert.equal(listPage.issues.some((issue) => issue.type === "list-or-index"), true)
+
+const chineseIndexPage = evaluateArticleQuality({
+  ...highQualityArticle,
+  title: "物理学家列表",
+  extract:
+    "物理学家列表收录了在物理学发展过程中具有一定影响的人物，并按照不同历史时期、研究方向和国籍进行整理，便于读者查找相关人物条目。",
+  categories: ["Category:科学家列表"],
+})
+
+assert.equal(chineseIndexPage.isHighQuality, false)
+assert.equal(chineseIndexPage.issues.some((issue) => issue.type === "list-or-index"), true)
+
+const stubPage = evaluateArticleQuality({
+  ...highQualityArticle,
+  title: "Small town biography",
+  categories: ["Category:Physics stubs"],
+})
+
+assert.equal(stubPage.isHighQuality, false)
+assert.equal(stubPage.issues.some((issue) => issue.type === "stub-or-low-context"), true)
+
+const missingUrl = evaluateArticleQuality({
+  ...highQualityArticle,
+  url: "",
+})
+
+assert.equal(missingUrl.isHighQuality, false)
+assert.equal(missingUrl.issues.some((issue) => issue.type === "missing-url"), true)
+
+const missingThumbnail = evaluateArticleQuality({
+  ...highQualityArticle,
+  thumbnail: undefined,
+})
+
+assert.equal(missingThumbnail.isHighQuality, false)
+assert.equal(missingThumbnail.issues.some((issue) => issue.type === "missing-thumbnail"), true)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,11 @@ import { useLocalization } from "./hooks/useLocalization"
 import { useScrollPosition } from "./hooks/useScrollPosition"
 import type { WikiArticle } from "./types/ArticleProps"
 import { fetchWithCORS } from "./utils/environment"
+import { isHighQualityArticle } from "./utils/articleQuality"
+
+const TARGET_ARTICLE_BATCH_SIZE = 20
+const RANDOM_CANDIDATE_BATCH_SIZE = 30
+const MAX_RANDOM_FETCH_ROUNDS = 3
 
 function App() {
   const [showAbout, setShowAbout] = useState(false)
@@ -30,54 +35,83 @@ function App() {
   // Query function to fetch a batch of random Wikipedia articles
   const queryFn = useMemo(() => {
     return async (): Promise<WikiArticle[]> => {
-      const response = await fetchWithCORS(
-        currentLanguage.api +
-          new URLSearchParams({
-            action: "query",
-            format: "json",
-            generator: "random",
-            grnnamespace: "0",
-            prop: "extracts|info|pageimages",
-            inprop: "url|varianttitles",
-            grnlimit: "20",
-            exintro: "1",
-            exlimit: "max",
-            exsentences: "5",
-            explaintext: "1",
-            piprop: "thumbnail",
-            pithumbsize: "480",
-            origin: "*",
-            variant: currentLanguage.id,
-          })
-      )
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
-      const data = await response.json()
-      if (!data.query || !data.query.pages) throw new Error("Invalid API response")
-
       type WikipediaThumbnail = { source: string; width: number; height: number }
+      type WikipediaCategory = { title: string; hidden?: string }
       type WikipediaPage = {
         title: string
         varianttitles?: Record<string, string>
-        extract: string
+        extract?: string
         pageid: number
         thumbnail?: WikipediaThumbnail
-        canonicalurl: string
+        canonicalurl?: string
+        categories?: WikipediaCategory[]
+      }
+      type WikipediaQueryResponse = {
+        query?: {
+          pages?: Record<string, WikipediaPage>
+        }
       }
 
-      const pages = data.query.pages as Record<string, WikipediaPage>
-      const newArticles = Object.values(pages)
-        .map(
+      const articles: WikiArticle[] = []
+      const seenPageIds = new Set<number>()
+
+      for (let round = 0; round < MAX_RANDOM_FETCH_ROUNDS; round += 1) {
+        const response = await fetchWithCORS(
+          currentLanguage.api +
+            new URLSearchParams({
+              action: "query",
+              format: "json",
+              generator: "random",
+              grnnamespace: "0",
+              prop: "extracts|info|pageimages|categories",
+              inprop: "url|varianttitles",
+              grnlimit: String(RANDOM_CANDIDATE_BATCH_SIZE),
+              exintro: "1",
+              exlimit: "max",
+              exsentences: "5",
+              explaintext: "1",
+              piprop: "thumbnail",
+              pithumbsize: "480",
+              cllimit: "max",
+              clshow: "!hidden",
+              origin: "*",
+              variant: currentLanguage.id,
+            })
+        )
+
+        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
+
+        const data = (await response.json()) as WikipediaQueryResponse
+        const pages = data.query?.pages
+        if (!pages) throw new Error("Invalid API response")
+
+        const candidates = Object.values(pages).map(
           (page): WikiArticle => ({
             title: page.title,
             displaytitle: page.varianttitles?.[currentLanguage.id] || page.title,
-            extract: page.extract,
+            extract: page.extract ?? "",
             pageid: page.pageid,
             thumbnail: page.thumbnail,
-            url: page.canonicalurl,
+            url: page.canonicalurl ?? "",
+            categories: page.categories?.map((category) => category.title) ?? [],
           })
         )
-        .filter((a) => a.thumbnail && a.thumbnail.source && a.url && a.extract)
-      return newArticles
+
+        for (const candidate of candidates) {
+          if (seenPageIds.has(candidate.pageid)) continue
+          seenPageIds.add(candidate.pageid)
+
+          if (isHighQualityArticle(candidate)) {
+            articles.push(candidate)
+          }
+
+          if (articles.length >= TARGET_ARTICLE_BATCH_SIZE) {
+            return articles
+          }
+        }
+      }
+
+      return articles
     }
   }, [currentLanguage])
 

--- a/frontend/src/types/ArticleProps.ts
+++ b/frontend/src/types/ArticleProps.ts
@@ -11,6 +11,7 @@ export interface WikiArticle {
     width: number;
     height: number;
   };
+  categories?: string[];
 }
 
 export interface ArticleProps {

--- a/frontend/src/utils/articleQuality.ts
+++ b/frontend/src/utils/articleQuality.ts
@@ -1,0 +1,270 @@
+export type ArticleQualityIssueType =
+  | "missing-url"
+  | "missing-thumbnail"
+  | "empty-extract"
+  | "short-extract"
+  | "disambiguation"
+  | "list-or-index"
+  | "stub-or-low-context"
+
+export type ArticleQualityField = "title" | "extract" | "category" | "url" | "thumbnail"
+
+export interface ArticleQualityIssue {
+  type: ArticleQualityIssueType
+  field: ArticleQualityField
+  term?: string
+}
+
+export interface ArticleQualityInput {
+  title: string
+  displaytitle?: string
+  extract?: string
+  url?: string
+  thumbnail?: {
+    source?: string
+    width?: number
+    height?: number
+  }
+  categories?: readonly string[]
+}
+
+export interface ArticleQualityResult {
+  isHighQuality: boolean
+  issues: ArticleQualityIssue[]
+}
+
+export const MIN_MEANINGFUL_EXTRACT_CHARACTERS = 140
+export const MIN_MEANINGFUL_EXTRACT_WORDS = 18
+
+const DISAMBIGUATION_TITLE_TERMS = [
+  "(disambiguation)",
+  "disambiguation",
+  "may refer to",
+  "can refer to",
+  "refers to",
+  "消歧义",
+  "曖昧さ回避",
+  "Begriffsklärung",
+  "homonymie",
+] as const
+
+const DISAMBIGUATION_CATEGORY_TERMS = [
+  "disambiguation pages",
+  "all disambiguation pages",
+  "set index articles",
+  "surnames",
+  "given names",
+  "消歧义页",
+  "消歧義頁",
+  "曖昧さ回避",
+  "begriffsklärung",
+  "homonymie",
+] as const
+
+const DISAMBIGUATION_EXTRACT_PATTERNS = [
+  /\bmay refer to\b/i,
+  /\bcan refer to\b/i,
+  /\bmay stand for\b/i,
+  /\bcan stand for\b/i,
+  /\bmay mean\b/i,
+  /\bcan mean\b/i,
+  /\brefers to several\b/i,
+  /\bhas several meanings\b/i,
+  /可以指/i,
+  /可能指/i,
+  /可指/i,
+  /是一个消歧义/i,
+] as const
+
+const LIST_OR_INDEX_TITLE_PATTERNS = [
+  /^list of\b/i,
+  /^lists of\b/i,
+  /^index of\b/i,
+  /^outline of\b/i,
+  /^glossary of\b/i,
+  /^timeline of\b/i,
+  /^catalog(?:ue)? of\b/i,
+  /^一覧[:：]?/i,
+  /一覧$/i,
+  /^列表[:：]?/i,
+  /列表$/i,
+  /^索引[:：]?/i,
+  /索引$/i,
+] as const
+
+const LIST_OR_INDEX_CATEGORY_TERMS = [
+  "lists of",
+  "list of",
+  "indexes of",
+  "set index articles",
+  "glossaries",
+  "outlines",
+  "timelines of",
+  "catalogues",
+  "catalogs",
+  "列表",
+  "索引",
+  "一覧",
+] as const
+
+const STUB_OR_LOW_CONTEXT_CATEGORY_TERMS = [
+  "stub categories",
+  "stubs",
+  "stub articles",
+  "articles with short description",
+  "short description matches wikidata",
+  "小作品",
+  "小作品条目",
+  "スタブ",
+] as const
+
+function normalizeText(value: string): string {
+  return value
+    .normalize("NFKC")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[_\-–—:;,.!?()[\]{}]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase()
+}
+
+function normalizeCategory(category: string): string {
+  return normalizeText(category.replace(/^category\s*:/i, ""))
+}
+
+function wordCount(text: string): number {
+  const words = text.match(/[\p{L}\p{N}]+/gu)
+  return words?.length ?? 0
+}
+
+function hasCjkText(text: string): boolean {
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(text)
+}
+
+function containsAnyTerm(text: string, terms: readonly string[]): string | undefined {
+  const normalizedText = normalizeText(text)
+
+  return terms.find((term) => normalizedText.includes(normalizeText(term)))
+}
+
+function containsAnyCategoryTerm(categories: readonly string[], terms: readonly string[]): string | undefined {
+  for (const category of categories) {
+    const normalizedCategory = normalizeCategory(category)
+    const matchedTerm = terms.find((term) => normalizedCategory.includes(normalizeText(term)))
+
+    if (matchedTerm) {
+      return matchedTerm
+    }
+  }
+
+  return undefined
+}
+
+function matchesAnyPattern(text: string, patterns: readonly RegExp[]): string | undefined {
+  const normalizedTitle = normalizeText(text)
+  const originalText = text.trim()
+  const matchedPattern = patterns.find((pattern) => pattern.test(normalizedTitle) || pattern.test(originalText))
+
+  return matchedPattern?.source
+}
+
+function hasValidCanonicalUrl(url: string | undefined): boolean {
+  if (!url) return false
+
+  try {
+    const parsedUrl = new URL(url)
+    return parsedUrl.protocol === "https:" && parsedUrl.hostname.includes("wikipedia.org")
+  } catch {
+    return false
+  }
+}
+
+function hasUsableThumbnail(thumbnail: ArticleQualityInput["thumbnail"]): boolean {
+  if (!thumbnail?.source) return false
+
+  return (thumbnail.width ?? 0) > 0 && (thumbnail.height ?? 0) > 0
+}
+
+function evaluateExtractQuality(extract: string | undefined): ArticleQualityIssue[] {
+  const trimmedExtract = extract?.trim() ?? ""
+
+  if (!trimmedExtract) {
+    return [{ type: "empty-extract", field: "extract" }]
+  }
+
+  if (trimmedExtract.length < MIN_MEANINGFUL_EXTRACT_CHARACTERS) {
+    return [
+      {
+        type: "short-extract",
+        field: "extract",
+        term: `${trimmedExtract.length}/${MIN_MEANINGFUL_EXTRACT_CHARACTERS}`,
+      },
+    ]
+  }
+
+  if (!hasCjkText(trimmedExtract) && wordCount(trimmedExtract) < MIN_MEANINGFUL_EXTRACT_WORDS) {
+    return [
+      {
+        type: "short-extract",
+        field: "extract",
+        term: `${wordCount(trimmedExtract)}/${MIN_MEANINGFUL_EXTRACT_WORDS}`,
+      },
+    ]
+  }
+
+  return []
+}
+
+export function evaluateArticleQuality(input: ArticleQualityInput): ArticleQualityResult {
+  const titleText = [input.title, input.displaytitle].filter(Boolean).join(" ")
+  const categories = input.categories ?? []
+  const issues: ArticleQualityIssue[] = []
+
+  if (!hasValidCanonicalUrl(input.url)) {
+    issues.push({ type: "missing-url", field: "url" })
+  }
+
+  if (!hasUsableThumbnail(input.thumbnail)) {
+    issues.push({ type: "missing-thumbnail", field: "thumbnail" })
+  }
+
+  issues.push(...evaluateExtractQuality(input.extract))
+
+  const disambiguationTitleTerm = containsAnyTerm(titleText, DISAMBIGUATION_TITLE_TERMS)
+  const disambiguationCategoryTerm = containsAnyCategoryTerm(categories, DISAMBIGUATION_CATEGORY_TERMS)
+  const disambiguationExtractPattern = matchesAnyPattern(input.extract ?? "", DISAMBIGUATION_EXTRACT_PATTERNS)
+
+  if (disambiguationTitleTerm) {
+    issues.push({ type: "disambiguation", field: "title", term: disambiguationTitleTerm })
+  } else if (disambiguationCategoryTerm) {
+    issues.push({ type: "disambiguation", field: "category", term: disambiguationCategoryTerm })
+  } else if (disambiguationExtractPattern) {
+    issues.push({ type: "disambiguation", field: "extract", term: disambiguationExtractPattern })
+  }
+
+  const listTitlePattern = matchesAnyPattern(titleText, LIST_OR_INDEX_TITLE_PATTERNS)
+  const listCategoryTerm = containsAnyCategoryTerm(categories, LIST_OR_INDEX_CATEGORY_TERMS)
+
+  if (listTitlePattern) {
+    issues.push({ type: "list-or-index", field: "title", term: listTitlePattern })
+  } else if (listCategoryTerm) {
+    issues.push({ type: "list-or-index", field: "category", term: listCategoryTerm })
+  }
+
+  const stubCategoryTerm = containsAnyCategoryTerm(categories, STUB_OR_LOW_CONTEXT_CATEGORY_TERMS)
+
+  if (stubCategoryTerm) {
+    issues.push({ type: "stub-or-low-context", field: "category", term: stubCategoryTerm })
+  }
+
+  return {
+    isHighQuality: issues.length === 0,
+    issues,
+  }
+}
+
+export function isHighQualityArticle(input: ArticleQualityInput): boolean {
+  return evaluateArticleQuality(input).isHighQuality
+}


### PR DESCRIPTION
## Summary

Closes #5.

This PR adds a local article-quality filter for random Wikipedia results so Wikinote avoids low-value entries before rendering cards. It filters candidates with missing canonical URLs, missing usable thumbnails, empty or very short extracts, disambiguation pages, list/index/glossary/timeline pages, and stub or low-context categories. The random-article fetch now requests visible Wikipedia categories and over-fetches up to three rounds to preserve a useful batch size after filtering.

## Implementation notes

- Added `src/utils/articleQuality.ts` as a deterministic, local-only quality classifier.
- Extended `WikiArticle` with optional `categories` metadata.
- Updated the Wikipedia API query to request `categories` with `clshow=!hidden`.
- Replaced the previous single-pass thumbnail/extract/url filter with centralized `isHighQualityArticle` filtering and candidate refill logic.
- Added `scripts/test-article-quality.ts` and `npm run test:article-quality` for deterministic rule coverage.

## Validation

- `npm run test:article-quality` ✅
- `npm run lint` ✅ with the existing two Fast Refresh warnings in `LikedArticlesContext.tsx` and `ToastContext.tsx`
- `npm run build:all` ✅

## Notes

This PR is intentionally scoped to low-value Wikipedia article filtering. The sensitive/NSFW Safe Mode work remains in PR #11 and can be reconciled during merge ordering if both touch the same random article pipeline.